### PR TITLE
Implement wire color selection and xLights controller import

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,7 +3,7 @@
 ## 🔴 Critical Issues (Blocking Basic Functionality)
 
 ### Issue #1: xLights XML Parser Not Working
-**Status:** 🔴 In Progress
+**Status:** ✅ COMPLETED (2026-01-13)
 **Priority:** Critical
 **Description:** Parser doesn't recognize the xLights XML format with `<Networks><Controller>` and lowercase `<network>` elements.
 
@@ -53,47 +53,33 @@
 ---
 
 ### Issue #3: Wire Color Selection Not Working
-**Status:** 🔴 To Do
+**Status:** ✅ COMPLETED (2026-01-13)
 **Priority:** Medium
 **Description:** Wire color selector in toolbar doesn't affect newly created wires - all wires are black.
 
-**Current Behavior:**
-- Can select red/black/blue in toolbar
-- Creating wires always makes them black
-- Selected color not passed to wire creation logic
-
-**Expected Behavior:**
-- Selected color in toolbar affects new wire connections
-- Red = Power, Black = Data, Blue = Network
-- Wire color persists when saved/loaded
-
-**Files Involved:**
-- `src/components/Toolbar.tsx`
-- `src/components/DiagramCanvas.tsx`
-
-**Implementation:**
-- Pass `selectedWireColor` from Toolbar to DiagramCanvas
-- Use context or lift state to App.tsx
-- Update `onConnect` to use selected color
+**Solution Implemented:**
+- Lifted `selectedWireColor` state to App.tsx
+- Passed as props to both Toolbar and DiagramCanvas
+- Updated `onConnect` to use selected wire color
+- Now red/black/blue selection works correctly
 
 ---
 
 ## 🟡 High Priority Features
 
 ### Issue #4: Import Controllers from xLights
-**Status:** 🟡 To Do
+**Status:** ✅ COMPLETED (2026-01-13)
 **Priority:** High
 **Description:** Once parser works, add UI to import controllers from xLights file into diagram.
 
-**Expected Behavior:**
-- After connecting to xLights file, show "Import Controllers" button
-- Select which controllers to import
-- Automatically create controller nodes with proper:
-  - Name (from XML)
-  - Type (Vendor + Model)
-  - Ports (from `<network>` elements with universe numbers)
-  - Max pixels (calculated from MaxChannels ÷ 3)
-- Position nodes automatically or allow manual placement
+**Solution Implemented:**
+- After connecting to xLights, green "Import X Controller(s)" button appears
+- Automatically creates controller nodes with:
+  - Name from XML (e.g., "Megatree", "Main", "AC Lights")
+  - Type from Vendor + Model
+  - Ports from `<network>` elements with universe numbers
+  - Max pixels calculated from MaxChannels ÷ 3
+- Positions nodes in 3-column grid layout automatically
 
 ---
 
@@ -253,20 +239,42 @@ Custom node components with basic styling - **DONE**
 ### ✓ Store Synchronization
 Zustand store syncing with React Flow canvas - **DONE**
 
+### ✓ Issue #1: xLights XML Parser Working
+Parser now correctly handles `<Networks><Controller><network>` format - **DONE** (2026-01-13)
+
+### ✓ Issue #3: Wire Color Selection
+Wire colors (red/black/blue) now work correctly - **DONE** (2026-01-13)
+
+### ✓ Issue #4: Import Controllers from xLights
+Auto-import controllers with proper names, types, and ports - **DONE** (2026-01-13)
+
 ---
 
 ## Next Steps
 
 **Recommended Priority Order:**
 
-1. **Fix Issue #1** - Get xLights parser working (critical for main feature)
-2. **Fix Issue #3** - Wire color selection (quick fix, important for usability)
-3. **Implement Issue #2** - Property editing (needed before import)
-4. **Implement Issue #4** - Import from xLights (main value proposition)
+1. ✅ ~~**Fix Issue #1** - Get xLights parser working~~ **COMPLETED**
+2. ✅ ~~**Fix Issue #3** - Wire color selection~~ **COMPLETED**
+3. ✅ ~~**Implement Issue #4** - Import from xLights~~ **COMPLETED**
+4. **Implement Issue #2** - Property editing (needed for editing imported controllers)
 5. **Fix Bug #1** - Node positioning (UX improvement)
 6. **Implement Issue #5** - Node deletion (basic functionality)
-7. Continue with medium/low priority items
+7. **Implement Issue #6** - DIP switch UI (important for receivers)
+8. Continue with medium/low priority items
 
 ---
 
 **Last Updated:** 2026-01-13
+
+## Summary of Today's Progress (2026-01-13)
+
+✅ **Major accomplishments:**
+1. Fixed xLights XML parser to handle lowercase `<network>` elements
+2. Implemented wire color selection (red/black/blue)
+3. Implemented automatic controller import from xLights with proper names, types, and port configurations
+
+🎯 **Next recommended tasks:**
+- Issue #2: Property editing for nodes
+- Issue #5: Node deletion functionality
+- Issue #6: DIP switch configuration UI

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { DiagramCanvas } from './components/DiagramCanvas';
 import { Toolbar } from './components/Toolbar';
 import { useDiagramStore } from './store/diagramStore';
+import { WireColor } from './types/diagram';
 
 function App() {
   const { loadDiagram } = useDiagramStore();
+  const [selectedWireColor, setSelectedWireColor] = useState<WireColor>('black');
 
   useEffect(() => {
     // Load saved diagram on mount
@@ -39,8 +41,11 @@ function App() {
 
   return (
     <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
-      <Toolbar />
-      <DiagramCanvas />
+      <Toolbar
+        selectedWireColor={selectedWireColor}
+        onWireColorChange={setSelectedWireColor}
+      />
+      <DiagramCanvas selectedWireColor={selectedWireColor} />
     </div>
   );
 }

--- a/src/components/DiagramCanvas.tsx
+++ b/src/components/DiagramCanvas.tsx
@@ -40,7 +40,11 @@ const getWireColor = (color: WireColor): string => {
   }
 };
 
-export const DiagramCanvas = () => {
+interface DiagramCanvasProps {
+  selectedWireColor: WireColor;
+}
+
+export const DiagramCanvas = ({ selectedWireColor }: DiagramCanvasProps) => {
   const {
     controllers,
     receivers,
@@ -132,7 +136,7 @@ export const DiagramCanvas = () => {
     (connection: Connection) => {
       const newWire = {
         id: `wire-${Date.now()}`,
-        color: 'black' as WireColor,
+        color: selectedWireColor,
         from: {
           nodeId: connection.source!,
           portId: connection.sourceHandle || undefined,
@@ -151,7 +155,7 @@ export const DiagramCanvas = () => {
             ...connection,
             id: newWire.id,
             style: {
-              stroke: getWireColor('black'),
+              stroke: getWireColor(selectedWireColor),
               strokeWidth: 3,
             },
             type: 'smoothstep',
@@ -160,7 +164,7 @@ export const DiagramCanvas = () => {
         )
       );
     },
-    [addWire, setEdges]
+    [addWire, setEdges, selectedWireColor]
   );
 
   // Update store when nodes are dragged


### PR DESCRIPTION
Major features completed:
- Wire color selection: Users can now select red/black/blue for power/data/network wires
- xLights import: Automatically import controllers from xLights XML with proper names, types, and ports
- Parse xLights format: Support lowercase <network> elements with BaudRate and MaxChannels

Technical changes:
- Lifted selectedWireColor state to App.tsx for proper prop passing
- Added Import Controllers button that appears after connecting to xLights
- Auto-calculates max pixels per port from channels (÷3 for RGB)
- Positions imported controllers in 3-column grid layout
- Updated BACKLOG.md to reflect completed issues #1, #3, #4