### PR TITLE
Improve receiver and port visualization with independent models

### DIFF
--- a/src/components/nodes/PortNode.tsx
+++ b/src/components/nodes/PortNode.tsx
@@ -22,107 +22,131 @@ export const PortNode = memo(({ data }: NodeProps<PortNodeData>) => {
   const portColor = isOverBudget ? '#E53E3E' : isNearLimit ? '#DD6B20' : '#ECC94B';
 
   return (
-    <div
-      style={{
-        padding: '8px',
-        border: '2px solid #9AE6B4',
-        borderRadius: '50%',
-        background: portColor,
-        width: '60px',
-        height: '60px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'relative',
-      }}
-    >
-      {/* Connection handle from receiver */}
-      <Handle
-        type="target"
-        position={Position.Top}
-        id="port-input"
-        style={{
-          background: '#48BB78',
-          width: '8px',
-          height: '8px',
-          top: '-4px',
-        }}
-      />
-
-      {/* Connection handle for models */}
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        id="port-output"
-        style={{
-          background: '#2D3748',
-          width: '10px',
-          height: '10px',
-          bottom: '-5px',
-        }}
-      />
-
-      {/* Port number */}
-      <div
-        style={{
-          fontSize: '24px',
-          fontWeight: 'bold',
-          color: '#22543D',
-        }}
-      >
-        {portNumber}
-      </div>
-
-      {/* Tooltip on hover */}
+    <div style={{ position: 'relative' }}>
+      {/* Budget display above port circle */}
       <div
         style={{
           position: 'absolute',
-          bottom: '-80px',
+          top: '-22px',
           left: '50%',
           transform: 'translateX(-50%)',
-          background: 'white',
-          border: '2px solid #9AE6B4',
-          borderRadius: '4px',
-          padding: '6px',
-          minWidth: '120px',
-          fontSize: '9px',
-          pointerEvents: 'none',
-          opacity: 0,
-          transition: 'opacity 0.2s',
-          zIndex: 1000,
-        }}
-        className="port-tooltip"
-      >
-        <div style={{ fontWeight: 'bold', marginBottom: '2px' }}>{fullAddress}</div>
-        <div style={{
-          color: isOverBudget ? '#E53E3E' : isNearLimit ? '#DD6B20' : '#2F855A',
+          fontSize: '10px',
           fontWeight: 'bold',
-        }}>
-          {currentPixels}/{maxPixels}px
-        </div>
-        {remainingPixels >= 0 && (
-          <div style={{ fontSize: '8px', color: '#718096', marginTop: '2px' }}>
-            {remainingPixels}px left
-          </div>
-        )}
-        {models && models.length > 0 && (
-          <div style={{ marginTop: '4px', borderTop: '1px solid #E2E8F0', paddingTop: '4px' }}>
-            {models.map((model, idx) => (
-              <div key={idx} style={{ fontSize: '8px' }}>
-                • {model.name} ({model.pixels}px)
-              </div>
-            ))}
-          </div>
-        )}
+          color: isOverBudget ? '#E53E3E' : isNearLimit ? '#DD6B20' : '#2F855A',
+          whiteSpace: 'nowrap',
+          background: 'rgba(255, 255, 255, 0.9)',
+          padding: '2px 4px',
+          borderRadius: '3px',
+          border: '1px solid #E2E8F0',
+        }}
+      >
+        {currentPixels}/{maxPixels}
       </div>
 
-      <style>
-        {`
-          .port-tooltip:hover {
-            opacity: 1 !important;
-          }
-        `}
-      </style>
+      {/* Port circle */}
+      <div
+        style={{
+          padding: '6px',
+          border: '2px solid #9AE6B4',
+          borderRadius: '50%',
+          background: portColor,
+          width: '40px',
+          height: '40px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          position: 'relative',
+        }}
+      >
+        {/* Connection handle from receiver */}
+        <Handle
+          type="target"
+          position={Position.Top}
+          id="port-input"
+          style={{
+            background: '#48BB78',
+            width: '6px',
+            height: '6px',
+            top: '-3px',
+          }}
+        />
+
+        {/* Connection handle for models */}
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          id="port-output"
+          style={{
+            background: '#2D3748',
+            width: '8px',
+            height: '8px',
+            bottom: '-4px',
+          }}
+        />
+
+        {/* Port number */}
+        <div
+          style={{
+            fontSize: '18px',
+            fontWeight: 'bold',
+            color: '#22543D',
+          }}
+        >
+          {portNumber}
+        </div>
+      </div>
+
+        {/* Tooltip on hover */}
+        <div
+          style={{
+            position: 'absolute',
+            bottom: '-80px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: 'white',
+            border: '2px solid #9AE6B4',
+            borderRadius: '4px',
+            padding: '6px',
+            minWidth: '120px',
+            fontSize: '9px',
+            pointerEvents: 'none',
+            opacity: 0,
+            transition: 'opacity 0.2s',
+            zIndex: 1000,
+          }}
+          className="port-tooltip"
+        >
+          <div style={{ fontWeight: 'bold', marginBottom: '2px' }}>{fullAddress}</div>
+          <div style={{
+            color: isOverBudget ? '#E53E3E' : isNearLimit ? '#DD6B20' : '#2F855A',
+            fontWeight: 'bold',
+          }}>
+            {currentPixels}/{maxPixels}px
+          </div>
+          {remainingPixels >= 0 && (
+            <div style={{ fontSize: '8px', color: '#718096', marginTop: '2px' }}>
+              {remainingPixels}px left
+            </div>
+          )}
+          {models && models.length > 0 && (
+            <div style={{ marginTop: '4px', borderTop: '1px solid #E2E8F0', paddingTop: '4px' }}>
+              {models.map((model, idx) => (
+                <div key={idx} style={{ fontSize: '8px' }}>
+                  • {model.name} ({model.pixels}px)
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <style>
+          {`
+            .port-tooltip:hover {
+              opacity: 1 !important;
+            }
+          `}
+        </style>
+      </div>
     </div>
   );
 });

--- a/src/components/nodes/ReceiverNode.tsx
+++ b/src/components/nodes/ReceiverNode.tsx
@@ -16,10 +16,10 @@ export const ReceiverNode = memo(({ data }: NodeProps<ReceiverNodeData>) => {
   // Parse receiver number from dipSwitch (e.g., "0000" -> 0, "0001" -> 1)
   const receiverNumber = parseInt(receiver.dipSwitch, 10) || 0;
 
-  // Build hierarchy subtitle: "Differential Port X > Receiver Y"
-  const hierarchyText = receiver.differentialPortNumber
-    ? `Differential Port ${receiver.differentialPortNumber} > Receiver ${receiverNumber}`
-    : `Receiver ${receiverNumber}`;
+  // Build full address path for top-left display
+  const fullAddressPath = receiver.differentialPortNumber
+    ? `${receiver.differentialPortNumber}:${receiverNumber}`
+    : `${receiverNumber}`;
 
   const displayName = receiver.customName || receiver.name;
 
@@ -47,12 +47,12 @@ export const ReceiverNode = memo(({ data }: NodeProps<ReceiverNodeData>) => {
   return (
     <div
       style={{
-        padding: '12px',
+        padding: '8px',
         border: '2px solid #48BB78',
         borderRadius: '8px',
         background: '#C6F6D5',
-        width: '380px',
-        height: '280px',
+        width: '340px',
+        height: '120px',
         position: 'relative',
         overflow: 'visible', // Allow child nodes to extend beyond
       }}
@@ -107,7 +107,21 @@ export const ReceiverNode = memo(({ data }: NodeProps<ReceiverNodeData>) => {
         <Handle type="source" position={Position.Right} id="receiver-output-2" style={{ opacity: 0 }} />
       </div>
 
-      {/* Receiver name - editable on double-click */}
+      {/* Receiver number and address path in top-left */}
+      <div
+        style={{
+          position: 'absolute',
+          top: '8px',
+          left: '8px',
+          fontSize: '14px',
+          fontWeight: 'bold',
+          color: '#22543D',
+        }}
+      >
+        {receiverNumber} <span style={{ fontSize: '12px', fontWeight: 'normal', color: '#2F855A' }}>{fullAddressPath}</span>
+      </div>
+
+      {/* Receiver name - centered, big and bold */}
       {isEditing ? (
         <input
           type="text"
@@ -117,24 +131,33 @@ export const ReceiverNode = memo(({ data }: NodeProps<ReceiverNodeData>) => {
           onKeyDown={handleKeyDown}
           autoFocus
           style={{
-            width: '100%',
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: '80%',
             fontWeight: 'bold',
-            marginBottom: '4px',
             color: '#22543D',
             border: '2px solid #48BB78',
             borderRadius: '4px',
-            padding: '2px 4px',
-            fontSize: '14px',
+            padding: '4px 8px',
+            fontSize: '24px',
+            textAlign: 'center',
           }}
         />
       ) : (
         <div
           style={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
             fontWeight: 'bold',
-            marginBottom: '2px',
             color: '#22543D',
             cursor: 'pointer',
-            fontSize: '14px',
+            fontSize: '24px',
+            textAlign: 'center',
+            width: '80%',
           }}
           onDoubleClick={handleDoubleClick}
           title="Double-click to rename"
@@ -142,44 +165,6 @@ export const ReceiverNode = memo(({ data }: NodeProps<ReceiverNodeData>) => {
           {displayName}
         </div>
       )}
-
-      {/* Hierarchy subtitle */}
-      <div
-        style={{
-          fontSize: '10px',
-          color: '#2F855A',
-          marginBottom: '8px',
-          fontStyle: 'italic',
-          textAlign: 'center',
-        }}
-      >
-        {hierarchyText}
-      </div>
-
-      {/* Receiver number display */}
-      <div
-        style={{
-          fontSize: '48px',
-          fontWeight: 'bold',
-          color: '#22543D',
-          textAlign: 'center',
-          marginTop: '8px',
-        }}
-      >
-        {receiverNumber}
-      </div>
-
-      {/* Port count indicator */}
-      <div
-        style={{
-          fontSize: '10px',
-          color: '#2F855A',
-          textAlign: 'center',
-          marginTop: '8px',
-        }}
-      >
-        {receiver.ports.length} Ports
-      </div>
     </div>
   );
 });


### PR DESCRIPTION
Receiver Box Updates:
- Reduce size to 340x120px for more compact layout
- Move receiver number to top-left corner with full address path
- Center receiver name (large, bold) in middle of box
- Remove redundant "X Ports" text
- Increase text size for better readability

Port Circle Updates:
- Reduce size from 60x60px to 40x40px
- Add budget display above each port (currentPixels/maxPixels)
- Position ports to overlap bottom edge of receiver box (like ethernet ports)
- Update handle sizes and positioning

Model Node Updates:
- Make models independent nodes (not children of receiver)
- Models can now be dragged and moved independently
- Spread models horizontally per port (130px spacing)
- Stack models vertically with 55px spacing
- Add automatic black wire connections:
  - Port to first model
  - Model to model for chained models
- Model wires calculated in initialEdges for proper rendering

This addresses user feedback for:
1. Budget visibility above ports
2. Optimized space usage with smaller boxes
3. Larger, more readable text
4. Better visual hierarchy (number + address in corner, name centered)
5. Port overlap with receiver edge
6. Independent model nodes with black wire connections
7. Proper model spreading to avoid overlap